### PR TITLE
Adding a Mock Driver for Testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ before_script:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
   - go mod tidy
+  - echo $DOCKERHUB_TOKEN | docker login --username madflojo --password-stdin
 script:
   - gofmt -l ./ | grep -v vendor | wc -l | grep -q 0
   - go vet -v ./...

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 tests:
 	@echo "Launching Tests in Docker Compose"
 	docker-compose -f dev-compose.yml up --build tests
+
+cover:
 	@echo "Generating Coverage Report"
 	go tool cover -html=coverage/coverage.out -o coverage/coverage.html
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@
 tests:
 	@echo "Launching Tests in Docker Compose"
 	docker-compose -f dev-compose.yml up --build tests
+	@echo "Generating Coverage Report"
+	go tool cover -html=coverage/coverage.out -o coverage/coverage.html
 
 bench:
 	@echo "Launching Benchmarks in Docker Compose"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Hord
 
-[![Build 
-Status](https://travis-ci.org/madflojo/hord.svg)](
-https://travis-ci.org/madflojo/hord) ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/madflojo/hord) [![Coverage Status](https://coveralls.io/repos/github/madflojo/hord/badge.svg?branch=master)](https://coveralls.io/github/madflojo/hord?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/madflojo/hord)](https://goreportcard.com/report/github.com/madflojo/hord) [![Documentation](https://godoc.org/github.com/madflojo/hord?status.svg)](http://godoc.org/github.com/madflojo/hord)
+[![Build Status](https://travis-ci.com/madflojo/hord.svg?branch=master)](https://travis-ci.com/madflojo/hord)
+![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/madflojo/hord)
+[![Coverage Status](https://coveralls.io/repos/github/madflojo/hord/badge.svg?branch=master)](https://coveralls.io/github/madflojo/hord?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/madflojo/hord)](https://goreportcard.com/report/github.com/madflojo/hord)
+[![Documentation](https://godoc.org/github.com/madflojo/hord?status.svg)](http://godoc.org/github.com/madflojo/hord)
 
 
 Hord provides a modular key-value interface for interacting with databases. The goal is to provide a consistent interface regardless, of the underlying database.

--- a/drivers/mock/mock.go
+++ b/drivers/mock/mock.go
@@ -1,0 +1,204 @@
+// Package mock is a Hord database driver used to assist in testing. This package satisfies the Hord database interface
+// and can help applications using a Hord managed database.
+//
+// In using this package, users can create custom functions executed when calling the Database interface methods. Rather
+// than writing a mock for the Hord interface, initialize this driver in place of a standard database driver.
+//
+// 	func TestMocking(t *testing.T) {
+// 	        var db hord.Database
+// 	        cfg := Config{
+// 	                // Create a fake GET function
+// 	                GetFunc: func(key string) ([]byte, error) {
+// 	                        if key == "works" {
+// 	                                return []byte("Yes"), nil
+// 	                        }
+// 	                        return []byte{}, hord.ErrNil
+// 	                },
+// 	                // Create a fake SET function
+// 	                SetFunc: func(key string, data []byte) error {
+// 	                        if key == "works" {
+// 	                                return nil
+// 	                        }
+// 	                        return fmt.Errorf("Error inserting data")
+// 	                },
+// 	        }
+//
+// 	        db, err := Dial(cfg)
+// 	        if err != nil {
+// 	                t.Errorf("Unexpected error when creating Mock interface - %s", err)
+// 	        }
+//
+// 	        t.Run("Validate Get", func(t *testing.T) {
+// 	                _, err := db.Get("works")
+// 	                if err != nil {
+// 	                        t.Errorf("Get mocked function did not work as expected err returned - %s", err)
+// 	                }
+// 	        })
+//
+//	        t.Run("Validate Get Errors", func(t *testing.T) {
+//	                _, err := db.Get("doesntwork")
+//	                if err != hord.ErrNil {
+//	                        t.Errorf("Get mocked function did not work as expected err returned - %s", err)
+//	                }
+//	        })
+//
+// 	        t.Run("Validate Set", func(t *testing.T) {
+// 	                err := db.Set("works", []byte{})
+// 	                if err != nil {
+// 	                        t.Errorf("Set mocked function did not work as expected err returned - %s", err)
+// 	                }
+// 	        })
+//
+// 	        t.Run("Validate Set Errors", func(t *testing.T) {
+// 	                err := db.Set("doesntwork", []byte{})
+// 	                if err == nil {
+// 	                        t.Errorf("Set mocked function did not work as expected err returned - %s", err)
+// 	                }
+// 	        })
+// 	}
+//
+// This package, by default, offers a happy path for each mocked function. Custom functions only must be defined to alter
+// the default behavior.
+//
+package mock
+
+// Config is passed to Dial to configure this mock. By default, mocked functions will return with a happy path scenario.
+// To override and customize the return use the appropriate functions defined within the Config struct.
+type Config struct {
+	// SetupFunc allows users to define a custom function executed in place of the default Database Setup method.
+	SetupFunc func() error
+
+	// HealthCheckFunc allows users to define a custom function executed in place of the default Database HealthCheck
+	// method.
+	HealthCheckFunc func() error
+
+	// GetFunc allows users to define a custom function executed in place of the default Database Get method.
+	GetFunc func(string) ([]byte, error)
+
+	// SetFunc allows users to define a custom function executed in place of the default Database Set method.
+	SetFunc func(string, []byte) error
+
+	// DeleteFunc allows users to define a custom function executed in place of the default Database Delete method.
+	DeleteFunc func(string) error
+
+	// KeysFunc allows users to define a custom function executed in place of the default Database Keys method.
+	KeysFunc func() ([]string, error)
+}
+
+// Database is an object returned by the Dial function. This struct satisfies the Hord Database interface and can
+// provide mocked functionality for the Hord interface.
+type Database struct {
+	// setupFunc allows users to define a custom function executed in place of the default Database Setup method.
+	setupFunc func() error
+
+	// healthCheckFunc allows users to define a custom function executed in place of the default Database HealthCheck
+	// method.
+	healthCheckFunc func() error
+
+	// getFunc allows users to define a custom function executed in place of the default Database Get method.
+	getFunc func(string) ([]byte, error)
+
+	// setFunc allows users to define a custom function executed in place of the default Database Set method.
+	setFunc func(string, []byte) error
+
+	// deleteFunc allows users to define a custom function executed in place of the default Database Delete method.
+	deleteFunc func(string) error
+
+	// keysFunc allows users to define a custom function executed in place of the default Database Keys method.
+	keysFunc func() ([]string, error)
+}
+
+// Dial will mock connecting to a remote database. Users can use the returned Database object to fake interactions
+// with a Hord Database.
+//
+//          var db hord.Database
+//          cfg := Config{
+//                  // Create a fake GET function
+//                  GetFunc: func(key string) ([]byte, error) {
+//                          if key == "works" {
+//                                  return []byte("Yes"), nil
+//                          }
+//                          return []byte{}, hord.ErrNil
+//                  },
+//                  // Create a fake SET function
+//                  SetFunc: func(key string, data []byte) error {
+//                          if key == "works" {
+//                                  return nil
+//                          }
+//                          return fmt.Errorf("Error inserting data")
+//                  },
+//          }
+//
+//          db, err := Dial(cfg)
+//          if err != nil {
+//                  t.Errorf("Unexpected error when creating Mock interface - %s", err)
+//          }
+//
+func Dial(c Config) (*Database, error) {
+	db := &Database{}
+	db.setupFunc = c.SetupFunc
+	db.healthCheckFunc = c.HealthCheckFunc
+	db.getFunc = c.GetFunc
+	db.setFunc = c.SetFunc
+	db.deleteFunc = c.DeleteFunc
+	db.keysFunc = c.KeysFunc
+	return db, nil
+}
+
+// Setup provides a mocked function, which, when executed without any configuration, will return nil. If Users have
+// defined a custom Setup function, Setup will run the custom function producing the results.
+func (db Database) Setup() error {
+	if db.setupFunc != nil {
+		return db.setupFunc()
+	}
+	return nil
+}
+
+// HealthCheck provides a mocked function, which, when executed without any configuration, will return nil. If Users
+// have defined a custom HealthCheck function, HealthCheck will run the custom function producing the results.
+func (db Database) HealthCheck() error {
+	if db.healthCheckFunc != nil {
+		return db.healthCheckFunc()
+	}
+	return nil
+}
+
+// Get provides a mocked function, which will return an empty byte slice and no error when executed without any
+// configuration. If Users have defined a custom Get function, Get will run the custom function producing the results.
+func (db Database) Get(key string) ([]byte, error) {
+	if db.getFunc != nil {
+		return db.getFunc(key)
+	}
+	return []byte{}, nil
+}
+
+// Set provides a mocked function, which will return no error when executed without any configuration. If
+// Users have defined a custom Set function, Set will run the custom function producing the results.
+func (db Database) Set(key string, data []byte) error {
+	if db.setFunc != nil {
+		return db.setFunc(key, data)
+	}
+	return nil
+}
+
+// Delete provides a mocked function, which will return no error when executed without any configuration.
+// If Users have defined a custom Delete function, Delete will run the custom function producing the results.
+func (db Database) Delete(key string) error {
+	if db.deleteFunc != nil {
+		return db.deleteFunc(key)
+	}
+	return nil
+}
+
+// Keys provides a mocked function, which will return an empty string slice with no error when executed
+// without any configuration. If Users have defined a custom Keys function, Keys will run the custom
+// function producing the results.
+func (db Database) Keys() ([]string, error) {
+	if db.keysFunc != nil {
+		return db.keysFunc()
+	}
+	return []string{}, nil
+}
+
+// Close, when called, will return and not act. Use this function to mock a Close Database call.
+func (db Database) Close() {}

--- a/drivers/mock/mock.go
+++ b/drivers/mock/mock.go
@@ -6,7 +6,7 @@
 //
 // 	func TestMocking(t *testing.T) {
 // 	        var db hord.Database
-// 	        cfg := Config{
+// 	        cfg := mock.Config{
 // 	                // Create a fake GET function
 // 	                GetFunc: func(key string) ([]byte, error) {
 // 	                        if key == "works" {
@@ -23,7 +23,7 @@
 // 	                },
 // 	        }
 //
-// 	        db, err := Dial(cfg)
+// 	        db, err := mock.Dial(cfg)
 // 	        if err != nil {
 // 	                t.Errorf("Unexpected error when creating Mock interface - %s", err)
 // 	        }
@@ -112,7 +112,7 @@ type Database struct {
 // with a Hord Database.
 //
 //          var db hord.Database
-//          cfg := Config{
+//          cfg := mock.Config{
 //                  // Create a fake GET function
 //                  GetFunc: func(key string) ([]byte, error) {
 //                          if key == "works" {
@@ -129,7 +129,7 @@ type Database struct {
 //                  },
 //          }
 //
-//          db, err := Dial(cfg)
+//          db, err := mock.Dial(cfg)
 //          if err != nil {
 //                  t.Errorf("Unexpected error when creating Mock interface - %s", err)
 //          }

--- a/drivers/mock/mock_test.go
+++ b/drivers/mock/mock_test.go
@@ -1,0 +1,173 @@
+package mock
+
+import (
+	"fmt"
+	"github.com/madflojo/hord"
+	"testing"
+)
+
+func TestDefaults(t *testing.T) {
+	var db hord.Database
+	db, err := Dial(Config{})
+	if err != nil {
+		t.Errorf("Unexepected error when creating Mock interface - %s", err)
+	}
+	defer db.Close()
+
+	t.Run("Validate Setup", func(t *testing.T) {
+		err := db.Setup()
+		if err != nil {
+			t.Errorf("Setup mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate HealthCheck", func(t *testing.T) {
+		err := db.HealthCheck()
+		if err != nil {
+			t.Errorf("HealthCheck mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Get", func(t *testing.T) {
+		r, err := db.Get("works")
+		if err != nil || len(r) != 0 {
+			t.Errorf("Get mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Set", func(t *testing.T) {
+		err := db.Set("works", []byte{})
+		if err != nil {
+			t.Errorf("Set mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Delete", func(t *testing.T) {
+		err := db.Delete("works")
+		if err != nil {
+			t.Errorf("Delete mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Keys", func(t *testing.T) {
+		keys, err := db.Keys()
+		if err != nil {
+			t.Errorf("Keys mocked function did not work as expected err returned - %s", err)
+		}
+		if len(keys) != 0 {
+			t.Errorf("Keys mocked function did not work as expected returned %d values", len(keys))
+		}
+	})
+}
+
+func TestMocking(t *testing.T) {
+	var db hord.Database
+	cfg := Config{
+		// Create a fake Setup function
+		SetupFunc: func() error {
+			return fmt.Errorf("This is an error")
+		},
+		// Create a fake HealthCheck function
+		HealthCheckFunc: func() error {
+			return fmt.Errorf("This is an error")
+		},
+		// Create a fake GET function
+		GetFunc: func(key string) ([]byte, error) {
+			if key == "works" {
+				return []byte("Yes"), nil
+			}
+			return []byte{}, hord.ErrNil
+		},
+		// Create a fake SET function
+		SetFunc: func(key string, data []byte) error {
+			if key == "works" {
+				return nil
+			}
+			return fmt.Errorf("Error inserting data")
+		},
+		// Create a fake Delete function
+		DeleteFunc: func(key string) error {
+			if key == "works" {
+				return nil
+			}
+			return fmt.Errorf("Error deleting data")
+		},
+		// Create a fake Keys function
+		KeysFunc: func() ([]string, error) {
+			return []string{"key1", "key2"}, nil
+		},
+	}
+
+	db, err := Dial(cfg)
+	if err != nil {
+		t.Errorf("Unexpected error when creating Mock interface - %s", err)
+	}
+	defer db.Close()
+
+	t.Run("Validate Setup", func(t *testing.T) {
+		err := db.Setup()
+		if err == nil {
+			t.Errorf("Setup mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate HealthCheck", func(t *testing.T) {
+		err := db.HealthCheck()
+		if err == nil {
+			t.Errorf("HealthCheck mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Get", func(t *testing.T) {
+		_, err := db.Get("works")
+		if err != nil {
+			t.Errorf("Get mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Get Errors", func(t *testing.T) {
+		_, err := db.Get("doesntwork")
+		if err != hord.ErrNil {
+			t.Errorf("Get mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Set", func(t *testing.T) {
+		err := db.Set("works", []byte{})
+		if err != nil {
+			t.Errorf("Set mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Set Errors", func(t *testing.T) {
+		err := db.Set("doesntwork", []byte{})
+		if err == nil {
+			t.Errorf("Set mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Delete", func(t *testing.T) {
+		err := db.Delete("works")
+		if err != nil {
+			t.Errorf("Delete mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Delete Errors", func(t *testing.T) {
+		err := db.Delete("doesntwork")
+		if err == nil {
+			t.Errorf("Delete mocked function did not work as expected err returned - %s", err)
+		}
+	})
+
+	t.Run("Validate Keys", func(t *testing.T) {
+		keys, err := db.Keys()
+		if err != nil {
+			t.Errorf("Keys mocked function did not work as expected err returned - %s", err)
+		}
+		if len(keys) != 2 {
+			t.Errorf("Keys mocked function did not work as expected returned %d values", len(keys))
+		}
+	})
+
+}


### PR DESCRIPTION
# Description

This change adds a Mock database driver that applications can use for testing. This driver works by having a set of predefined happy path answers. However, users can also set up custom functions to be executed and returned in place of the happy path values.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, ensuring GoDoc readability and clarity in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [X] I have added tests that ensure my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules

If checklist items are unchecked please explain.
