### PR TITLE
Adding test for protocol compatible alternative databases

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -71,6 +71,40 @@ jobs:
         sleep 60
         /usr/local/go/bin/go test -run=Benchmark -bench "BenchmarkDrivers/Bench_Redis" ./...
 
+  dragonfly:
+    runs-on: ubuntu-latest
+    container: madflojo/ubuntu-build
+    services:
+      dragonfly:
+        image: docker.dragonflydb.io/dragonflydb/dragonfly
+    steps:
+    - uses: actions/checkout@v3
+    # Using this instead of actions/setup-go to get around an issue with act
+    - name: Install Go
+      run: |
+           curl -L https://go.dev/dl/go1.19.9.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+    - name: Execute Benchmarks
+      run: |
+        sleep 60
+        /usr/local/go/bin/go test -run=Benchmark -bench "BenchmarkDrivers/Bench_Dragonfly" ./...
+
+  keydb:
+    runs-on: ubuntu-latest
+    container: madflojo/ubuntu-build
+    services:
+      keydb:
+        image: eqalpha/keydb
+    steps:
+    - uses: actions/checkout@v3
+    # Using this instead of actions/setup-go to get around an issue with act
+    - name: Install Go
+      run: |
+           curl -L https://go.dev/dl/go1.19.9.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+    - name: Execute Benchmarks
+      run: |
+        sleep 60
+        /usr/local/go/bin/go test -run=Benchmark -bench "BenchmarkDrivers/Bench_KeyDB" ./...
+
   nats:
     runs-on: ubuntu-latest
     container: madflojo/ubuntu-build

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -77,6 +77,7 @@ jobs:
     services:
       dragonfly:
         image: docker.dragonflydb.io/dragonflydb/dragonfly
+        options: --ulimit memlock=-1
     steps:
     - uses: actions/checkout@v3
     # Using this instead of actions/setup-go to get around an issue with act

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,12 @@ jobs:
     runs-on: ubuntu-latest
     container: madflojo/ubuntu-build
     services:
+      dragonfly:
+        image: docker.dragonflydb.io/dragonflydb/dragonfly
+
+      keydb:
+        image: eqalpha/keydb
+
       redis:
         image: bitnami/redis:latest
         # Set health checks to wait until redis has started

--- a/README.md
+++ b/README.md
@@ -11,17 +11,15 @@ Additionally, to facilitate testing, Hord includes a mock driver package that en
 
 ## Database Drivers:
 
-| Database | Support | Comments |
-| -------- | ------- | -------- |
-| BoltDB | ✅ | |
-| Cassandra | ✅ | |
-| Couchbase | Pending ||
-| DynamoDB | Pending ||
-| Hashmap | ✅ ||
-| Mock | ✅ | Mock Database interactions within unit tests |
-| NATS | ✅ | Experimental |
-| Redis | ✅ ||
-| ScyllaDB | ✅ | Experimental | 
+| Database | Support | Comments | Protocol Compatible Alternatives |
+| -------- | ------- | -------- | -------------------------------- |
+| [BoltDB](https://github.com/etcd-io/bbolt) | ✅ | | |
+| [Cassandra](https://cassandra.apache.org/) | ✅ | | [ScyllaDB](https://www.scylladb.com/), [YugabyteDB](https://www.yugabyte.com/), [Azure Cosmos DB](https://learn.microsoft.com/en-us/azure/cosmos-db/introduction) |
+| [Couchbase](https://www.couchbase.com/) | Pending |||
+| Hashmap | ✅ |||
+| Mock | ✅ | Mock Database interactions within unit tests ||
+| [NATS](https://nats.io/) | ✅ | Experimental ||
+| [Redis](https://redis.io/) | ✅ || [Dragonfly](https://www.dragonflydb.io/), [KeyDB](https://docs.keydb.dev/) |
 
 ## Usage
 

--- a/benchmarks/benchmark_test.go
+++ b/benchmarks/benchmark_test.go
@@ -26,7 +26,7 @@ func BenchmarkDrivers(b *testing.B) {
   `)
 
 	// Create a Set of drivers to benchmark
-	drivers := []string{"Redis", "Cassandra", "Hashmap", "BoltDB", "NATS"}
+	drivers := []string{"Redis", "Cassandra", "Hashmap", "BoltDB", "NATS", "Dragonfly", "KeyDB"}
 
 	// Loop through the various DBs and TestData
 	for _, driver := range drivers {
@@ -34,7 +34,17 @@ func BenchmarkDrivers(b *testing.B) {
 			var db hord.Database
 			var err error
 			switch driver {
-			case "Redis":
+			case "Redis", "Dragonfly", "KeyDB":
+				server = "redis:6379"
+				// Connect to Dragonfly
+				if driver == "Dragonfly" {
+					server = "dragonfly:6379"
+				}
+				// Connect to KeyDB
+				if driver == "KeyDB" {
+					server = "keydb:6379"
+				}
+
 				// Connect to Redis
 				db, err = redis.Dial(redis.Config{
 					ConnectTimeout: time.Duration(5) * time.Second,

--- a/benchmarks/benchmark_test.go
+++ b/benchmarks/benchmark_test.go
@@ -35,7 +35,7 @@ func BenchmarkDrivers(b *testing.B) {
 			var err error
 			switch driver {
 			case "Redis", "Dragonfly", "KeyDB":
-				server = "redis:6379"
+				server := "redis:6379"
 				// Connect to Dragonfly
 				if driver == "Dragonfly" {
 					server = "dragonfly:6379"
@@ -51,7 +51,7 @@ func BenchmarkDrivers(b *testing.B) {
 					MaxActive:      500,
 					MaxIdle:        100,
 					IdleTimeout:    time.Duration(5) * time.Second,
-					Server:         "redis:6379",
+					Server:         server,
 				})
 				if err != nil {
 					b.Fatalf("Got unexpected error when connecting to Redis - %s", err)

--- a/drivers/redis/common_test.go
+++ b/drivers/redis/common_test.go
@@ -28,6 +28,20 @@ func TestInterfaceHappyPath(t *testing.T) {
 		IdleTimeout:    time.Duration(5) * time.Second,
 		Server:         "redis:6379",
 	}
+	cfgs["Dragonfly with optimized settings"] = Config{
+		ConnectTimeout: time.Duration(5) * time.Second,
+		MaxActive:      500,
+		MaxIdle:        100,
+		IdleTimeout:    time.Duration(5) * time.Second,
+		Server:         "dragonfly:6379",
+	}
+	cfgs["KeyDB with optimized settings"] = Config{
+		ConnectTimeout: time.Duration(5) * time.Second,
+		MaxActive:      500,
+		MaxIdle:        100,
+		IdleTimeout:    time.Duration(5) * time.Second,
+		Server:         "keydb:6379",
+	}
 
 	// Loop through valid Configs and validate the driver adheres to the Hord interface
 	for name, cfg := range cfgs {


### PR DESCRIPTION
Several databases have protocol-compatible alternatives, such as Dragonfly for Redis or ScyllaDB for Cassandra.

This PR adds some tests for those alternatives.