### PR TITLE
Adding a Cache Driver

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -170,3 +170,59 @@ jobs:
       run: /usr/local/go/bin/go test -v -race -covermode=atomic -coverprofile=coverage.out ./drivers/bbolt
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+
+  cache:
+    runs-on: ubuntu-latest
+    container: madflojo/ubuntu-build
+    services:
+      cassandra-primary:
+        image: madflojo/cassandra:latest
+        env:
+          CASSANDRA_KEYSPACE: hord
+        ports:
+          - 7000
+          - 7001
+          - 7199
+          - 9042
+          - 9160
+
+      cassandra:
+        image: madflojo/cassandra:latest
+        env:
+          CASSANDRA_SEEDS: cassandra-primary
+          CASSANDRA_KEYSPACE: hord
+          SLEEP_TIMER: 15
+        ports:
+          - 7000
+          - 7001
+          - 7199
+          - 9042
+          - 9160
+
+      redis:
+        image: bitnami/redis:latest
+        # Set health checks to wait until redis has started
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          ALLOW_EMPTY_PASSWORD: yes
+
+      redis-sentinel:
+        image: bitnami/redis-sentinel:latest
+        env:
+          REDIS_URL: redis://redis:6379
+
+    steps:
+    - uses: actions/checkout@v3
+    # Using this instead of actions/setup-go to get around an issue with act
+    - name: Install Go
+      run: |
+           sleep 120 
+           curl -L https://go.dev/dl/go1.22.0.linux-amd64.tar.gz | tar -C /usr/local -xzf -
+    - name: Execute Tests
+      run: /usr/local/go/bin/go test -v -race -covermode=atomic -coverprofile=coverage.out ./drivers/cache
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3

--- a/drivers/cache/cache.go
+++ b/drivers/cache/cache.go
@@ -1,0 +1,214 @@
+/*
+Package cache provides a Hord database driver for a look-aside cache. To use this driver, import it as follows:
+
+	import (
+	    "github.com/madflojo/hord"
+	    "github.com/madflojo/hord/cache"
+	)
+
+# Connecting to the Database
+
+Use the Dial() function to create a new client for interacting with the cache.
+
+	// Handle database connection
+	var database hord.Database
+	...
+
+	// Handle cache connection
+	var cache hord.Database
+	...
+
+	var db hord.Database
+	db, err := cache.Dial(cache.Config{
+		Database: database,
+		Cache: 	  cache,
+	})
+	if err != nil {
+	    // Handle connection error
+	}
+
+# Initialize database
+
+Hord provides a Setup() function for preparing a database. This function is safe to execute after every Dial().
+
+	err := db.Setup()
+	if err != nil {
+	    // Handle setup error
+	}
+
+# Database Operations
+
+Hord provides a simple abstraction for working with the cache, with easy-to-use methods such as Get() and Set() to read and write values.
+
+	// Handle database connection
+	var database hord.Database
+	database, err := cassandra.Dial(cassandra.Config{})
+	if err != nil {
+		// Handle connection error
+	}
+
+	// Handle cache connection
+	var cache hord.Database
+	cache, err := redis.Dial(redis.Config{})
+	if err != nil {
+		// Handle connection error
+	}
+
+	// Connect to the Cache database
+	db, err := cache.Dial(cache.Config{
+		Database: database,
+		Cache: 	  cache,
+	})
+	if err != nil {
+	    // Handle connection error
+	}
+
+	err := db.Setup()
+	if err != nil {
+	    // Handle setup error
+	}
+
+	// Set a value
+	err = db.Set("key", []byte("value"))
+	if err != nil {
+	    // Handle error
+	}
+
+	// Retrieve a value
+	value, err := db.Get("key")
+	if err != nil {
+	    // Handle error
+	}
+*/
+
+package cache
+
+import (
+	"errors"
+
+	"github.com/madflojo/hord"
+)
+
+// Config provides the configuration options for the Cache driver.
+type Config struct {
+	Database hord.Database
+	Cache    hord.Database
+}
+
+// Cache is used to store data in a look-aside caching pattern. It also satisfies the Hord database interface.
+type Cache struct {
+	data  hord.Database
+	cache hord.Database
+}
+
+var (
+	// ErrInvalidDatabase is returned when a database is nil.
+	ErrInvalidDatabase = errors.New("database cannot be nil")
+
+	// ErrInvalidCache is returned when a cache is nil.
+	ErrInvalidCache = errors.New("cache cannot be nil")
+)
+
+// Dial will create a new Cache driver using the provided Config. It will return an error if either the Database or Cache values in Config are nil.
+func Dial(cfg Config) (*Cache, error) {
+	if cfg.Database == nil {
+		return nil, ErrInvalidDatabase
+	}
+
+	if cfg.Cache == nil {
+		return nil, ErrInvalidCache
+	}
+
+	return &Cache{
+		data:  cfg.Database,
+		cache: cfg.Cache,
+	}, nil
+}
+
+// Setup will run the Setup function for both the database and the cache.
+func (db *Cache) Setup() error {
+	if err := db.data.Setup(); err != nil {
+		return err
+	}
+
+	if err := db.cache.Setup(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// HealthCheck will run the HealthCheck function for both the database and the cache.
+func (db *Cache) HealthCheck() error {
+	dataErr := db.data.HealthCheck()
+	cacheErr := db.cache.HealthCheck()
+
+	if dataErr != nil {
+		return dataErr
+	} else if cacheErr != nil {
+		return cacheErr
+	}
+
+	return nil
+}
+
+// Get will get the data from the database. It uses a look-aside pattern to store the data in the cache if it is not already there.
+func (db *Cache) Get(key string) ([]byte, error) {
+	// Check the cache first
+	data, err := db.cache.Get(key)
+	if (err != nil) && !errors.Is(err, hord.ErrNil) {
+		return nil, err
+	} else if !errors.Is(err, hord.ErrNil) {
+		return data, nil
+	}
+
+	// Check the data database
+	data, err = db.data.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	db.cache.Set(key, data)
+
+	return data, nil
+}
+
+// Set will set the data in both the data and cache databases.
+func (db *Cache) Set(key string, data []byte) error {
+	err := db.data.Set(key, data)
+	if err != nil {
+		return err
+	}
+
+	// Update cache only if database Set was successful
+	err = db.cache.Set(key, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete will delete the data from both the data and cache databases.
+func (db *Cache) Delete(key string) error {
+	dataErr := db.data.Delete(key)
+	cacheErr := db.cache.Delete(key)
+
+	if dataErr != nil {
+		return dataErr
+	} else if cacheErr != nil {
+		return cacheErr
+	}
+
+	return nil
+}
+
+// Keys will return the keys from the data database.
+func (db *Cache) Keys() ([]string, error) {
+	return db.data.Keys()
+}
+
+// Close will close the connections to both the database and the cache.
+func (db *Cache) Close() {
+	db.data.Close()
+	db.cache.Close()
+}

--- a/drivers/cache/cache.go
+++ b/drivers/cache/cache.go
@@ -127,6 +127,10 @@ func Dial(cfg Config) (*Cache, error) {
 
 // Setup will run the Setup function for both the database and the cache.
 func (db *Cache) Setup() error {
+	if db == nil || db.data == nil || db.cache == nil {
+		return hord.ErrNoDial
+	}
+
 	if err := db.data.Setup(); err != nil {
 		return err
 	}
@@ -140,6 +144,10 @@ func (db *Cache) Setup() error {
 
 // HealthCheck will run the HealthCheck function for both the database and the cache.
 func (db *Cache) HealthCheck() error {
+	if db == nil || db.data == nil || db.cache == nil {
+		return hord.ErrNoDial
+	}
+
 	dataErr := db.data.HealthCheck()
 	cacheErr := db.cache.HealthCheck()
 
@@ -154,6 +162,10 @@ func (db *Cache) HealthCheck() error {
 
 // Get will get the data from the database. It uses a look-aside pattern to store the data in the cache if it is not already there.
 func (db *Cache) Get(key string) ([]byte, error) {
+	if db == nil || db.data == nil || db.cache == nil {
+		return nil, hord.ErrNoDial
+	}
+
 	// Check the cache first
 	data, err := db.cache.Get(key)
 	if (err != nil) && !errors.Is(err, hord.ErrNil) {
@@ -174,6 +186,10 @@ func (db *Cache) Get(key string) ([]byte, error) {
 
 // Set will set the data in both the data and cache databases.
 func (db *Cache) Set(key string, data []byte) error {
+	if db == nil || db.data == nil || db.cache == nil {
+		return hord.ErrNoDial
+	}
+
 	err := db.data.Set(key, data)
 	if err != nil {
 		return err
@@ -190,6 +206,10 @@ func (db *Cache) Set(key string, data []byte) error {
 
 // Delete will delete the data from both the data and cache databases.
 func (db *Cache) Delete(key string) error {
+	if db == nil || db.data == nil || db.cache == nil {
+		return hord.ErrNoDial
+	}
+
 	dataErr := db.data.Delete(key)
 	cacheErr := db.cache.Delete(key)
 
@@ -204,11 +224,17 @@ func (db *Cache) Delete(key string) error {
 
 // Keys will return the keys from the data database.
 func (db *Cache) Keys() ([]string, error) {
+	if db == nil || db.data == nil || db.cache == nil {
+		return nil, hord.ErrNoDial
+	}
+
 	return db.data.Keys()
 }
 
 // Close will close the connections to both the database and the cache.
 func (db *Cache) Close() {
-	db.data.Close()
-	db.cache.Close()
+	if db != nil && db.data != nil && db.cache != nil {
+		db.data.Close()
+		db.cache.Close()
+	}
 }

--- a/drivers/cache/cache.go
+++ b/drivers/cache/cache.go
@@ -85,6 +85,8 @@ Hord provides a simple abstraction for working with the cache, with easy-to-use 
 package cache
 
 import (
+	"errors"
+
 	"github.com/madflojo/hord"
 	"github.com/madflojo/hord/drivers/cache/lookaside"
 )
@@ -104,6 +106,11 @@ type Config struct {
 	Cache     hord.Database
 }
 
+var (
+	// ErrNoType is returned when the CacheType is invalid.
+	ErrNoType = errors.New("invalid CacheType")
+)
+
 // Dial will create a new Cache driver using the provided Config. It will return an error if either the Database or Cache values in Config are nil or if a CacheType is not specified.
 func Dial(cfg Config) (hord.Database, error) {
 	if (cfg.Database == nil) || (cfg.Cache == nil) {
@@ -111,12 +118,14 @@ func Dial(cfg Config) (hord.Database, error) {
 	}
 
 	switch cfg.CacheType {
-	case None:
-		return cfg.Database, nil
-	default:
+	case Lookaside:
 		return lookaside.Dial(lookaside.Config{
 			Database: cfg.Database,
 			Cache:    cfg.Cache,
 		})
+	case None:
+		return cfg.Database, nil
+	default:
+		return nil, ErrNoType
 	}
 }

--- a/drivers/cache/cache.go
+++ b/drivers/cache/cache.go
@@ -85,8 +85,6 @@ Hord provides a simple abstraction for working with the cache, with easy-to-use 
 package cache
 
 import (
-	"errors"
-
 	"github.com/madflojo/hord"
 	"github.com/madflojo/hord/drivers/cache/lookaside"
 )
@@ -106,11 +104,6 @@ type Config struct {
 	Cache     hord.Database
 }
 
-var (
-	// ErrNoType is returned when the CacheType is invalid.
-	ErrNoType = errors.New("invalid CacheType")
-)
-
 // Dial will create a new Cache driver using the provided Config. It will return an error if either the Database or Cache values in Config are nil or if a CacheType is not specified.
 func Dial(cfg Config) (hord.Database, error) {
 	if (cfg.Database == nil) || (cfg.Cache == nil) {
@@ -118,14 +111,12 @@ func Dial(cfg Config) (hord.Database, error) {
 	}
 
 	switch cfg.CacheType {
-	case Lookaside:
+	case None:
+		return cfg.Database, nil
+	default:
 		return lookaside.Dial(lookaside.Config{
 			Database: cfg.Database,
 			Cache:    cfg.Cache,
 		})
-	case None:
-		return cfg.Database, nil
-	default:
-		return nil, ErrNoType
 	}
 }

--- a/drivers/cache/cache.go
+++ b/drivers/cache/cache.go
@@ -80,7 +80,6 @@ Hord provides a simple abstraction for working with the cache, with easy-to-use 
 	    // Handle error
 	}
 */
-
 package cache
 
 import (
@@ -179,7 +178,12 @@ func (db *Cache) Get(key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	db.cache.Set(key, data)
+
+	// Update the cache
+	err = db.cache.Set(key, data)
+	if err != nil {
+		return data, err
+	}
 
 	return data, nil
 }

--- a/drivers/cache/cache_test.go
+++ b/drivers/cache/cache_test.go
@@ -31,11 +31,11 @@ func TestDial(t *testing.T) {
 		},
 		"Invalid Type": {
 			config: Config{
-				CacheType: "invalide",
+				CacheType: "invalid",
 				Database:  &mock.Database{},
 				Cache:     &mock.Database{},
 			},
-			expectedError: ErrNoType,
+			expectedError: nil,
 		},
 		"Type: Lookaside": {
 			config: Config{

--- a/drivers/cache/cache_test.go
+++ b/drivers/cache/cache_test.go
@@ -45,6 +45,14 @@ func TestDial(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		"Type: None": {
+			config: Config{
+				Type:     None,
+				Database: &mock.Database{},
+				Cache:    &mock.Database{},
+			},
+			expectedError: nil,
+		},
 	}
 
 	for name, test := range unitTests {
@@ -55,4 +63,27 @@ func TestDial(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNilCache(t *testing.T) {
+	nc := &NilCache{}
+	if err := nc.Setup(); !errors.Is(err, hord.ErrNoDial) {
+		t.Errorf("NilCache.Setup() returned error: %s, expected %s", err, hord.ErrNoDial)
+	}
+	if err := nc.HealthCheck(); !errors.Is(err, hord.ErrNoDial) {
+		t.Errorf("NilCache.HealthCheck() returned error: %s, expected %s", err, hord.ErrNoDial)
+	}
+	if _, err := nc.Get(""); !errors.Is(err, hord.ErrNoDial) {
+		t.Errorf("NilCache.Get() returned error: %s, expected %s", err, hord.ErrNoDial)
+	}
+	if err := nc.Set("", nil); !errors.Is(err, hord.ErrNoDial) {
+		t.Errorf("NilCache.Set() returned error: %s, expected %s", err, hord.ErrNoDial)
+	}
+	if err := nc.Delete(""); !errors.Is(err, hord.ErrNoDial) {
+		t.Errorf("NilCache.Delete() returned error: %s, expected %s", err, hord.ErrNoDial)
+	}
+	if _, err := nc.Keys(); !errors.Is(err, hord.ErrNoDial) {
+		t.Errorf("NilCache.Keys() returned error: %s, expected %s", err, hord.ErrNoDial)
+	}
+	nc.Close()
 }

--- a/drivers/cache/cache_test.go
+++ b/drivers/cache/cache_test.go
@@ -1,37 +1,12 @@
 package cache
 
 import (
-	"bytes"
 	"errors"
 	"testing"
 
 	"github.com/madflojo/hord"
 	"github.com/madflojo/hord/drivers/mock"
 )
-
-// Test Errors used for testing purposes
-var (
-	ErrDatabaseTest = errors.New("database error")
-	ErrCacheTest    = errors.New("cache error")
-)
-
-// setupCache is a helper function to create a new Cache driver using the provided database and cache Config.
-func setupCache(cacheConfig mock.Config, databaseConfig mock.Config) (*Cache, error) {
-	database, err := mock.Dial(databaseConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	cache, err := mock.Dial(cacheConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	return Dial(Config{
-		Database: database,
-		Cache:    cache,
-	})
-}
 
 func TestDial(t *testing.T) {
 	unitTests := map[string]struct {
@@ -40,24 +15,33 @@ func TestDial(t *testing.T) {
 	}{
 		"No Config": {
 			config:        Config{},
-			expectedError: ErrInvalidDatabase,
+			expectedError: hord.ErrInvalidDatabase,
 		},
 		"No Database": {
 			config: Config{
 				Cache: &mock.Database{},
 			},
-			expectedError: ErrInvalidDatabase,
+			expectedError: hord.ErrInvalidDatabase,
 		},
 		"No Cache": {
 			config: Config{
 				Database: &mock.Database{},
 			},
-			expectedError: ErrInvalidCache,
+			expectedError: hord.ErrInvalidDatabase,
 		},
-		"Happy Path": {
+		"Invalid Type": {
 			config: Config{
-				Database: &mock.Database{},
-				Cache:    &mock.Database{},
+				CacheType: "invalide",
+				Database:  &mock.Database{},
+				Cache:     &mock.Database{},
+			},
+			expectedError: ErrNoType,
+		},
+		"Type: Lookaside": {
+			config: Config{
+				CacheType: Lookaside,
+				Database:  &mock.Database{},
+				Cache:     &mock.Database{},
 			},
 			expectedError: nil,
 		},
@@ -71,391 +55,4 @@ func TestDial(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestSetup(t *testing.T) {
-	unitTests := map[string]struct {
-		databaseError error
-		cacheError    error
-		expectedError error
-	}{
-		"Database Error": {
-			databaseError: ErrDatabaseTest,
-			cacheError:    nil,
-			expectedError: ErrDatabaseTest,
-		},
-		"Cache Error": {
-			databaseError: nil,
-			cacheError:    ErrCacheTest,
-			expectedError: ErrCacheTest,
-		},
-		"Both Errors": {
-			databaseError: ErrDatabaseTest,
-			cacheError:    ErrCacheTest,
-			expectedError: ErrDatabaseTest,
-		},
-		"Happy Path": {
-			databaseError: nil,
-			cacheError:    nil,
-			expectedError: nil,
-		},
-	}
-
-	for name, test := range unitTests {
-		t.Run(name, func(t *testing.T) {
-			databaseConfig := mock.Config{
-				SetupFunc: func() error {
-					return test.databaseError
-				},
-			}
-			cacheConfig := mock.Config{
-				SetupFunc: func() error {
-					return test.cacheError
-				},
-			}
-
-			db, err := setupCache(cacheConfig, databaseConfig)
-			if err != nil {
-				t.Fatalf("Failed to connect to database - %s", err)
-			}
-
-			err = db.Setup()
-			if !errors.Is(err, test.expectedError) {
-				t.Errorf("Setup() returned error: %s, expected %s", err, test.expectedError)
-			}
-		})
-	}
-}
-
-func TestHealthCheck(t *testing.T) {
-	unitTests := map[string]struct {
-		databaseError error
-		cacheError    error
-		expectedError error
-	}{
-		"Database Error": {
-			databaseError: ErrDatabaseTest,
-			cacheError:    nil,
-			expectedError: ErrDatabaseTest,
-		},
-		"Cache Error": {
-			databaseError: nil,
-			cacheError:    ErrCacheTest,
-			expectedError: ErrCacheTest,
-		},
-		"Both Errors": {
-			databaseError: ErrDatabaseTest,
-			cacheError:    ErrCacheTest,
-			expectedError: ErrDatabaseTest,
-		},
-		"Happy Path": {
-			databaseError: nil,
-			cacheError:    nil,
-			expectedError: nil,
-		},
-	}
-
-	for name, test := range unitTests {
-		t.Run(name, func(t *testing.T) {
-			databaseConfig := mock.Config{
-				HealthCheckFunc: func() error {
-					return test.databaseError
-				},
-			}
-			cacheConfig := mock.Config{
-				HealthCheckFunc: func() error {
-					return test.cacheError
-				},
-			}
-
-			db, err := setupCache(cacheConfig, databaseConfig)
-			if err != nil {
-				t.Fatalf("Failed to connect to database - %s", err)
-			}
-
-			err = db.HealthCheck()
-			if !errors.Is(err, test.expectedError) {
-				t.Errorf("HealthCheck() returned error: %s, expected %s", err, test.expectedError)
-			}
-		})
-	}
-}
-
-func TestGet(t *testing.T) {
-	cacheConfig := mock.Config{
-		GetFunc: func(key string) ([]byte, error) {
-			switch key {
-			case "cache-hit":
-				return []byte("cache-data"), nil
-			case "cache-miss":
-				return nil, hord.ErrNil
-			case "cache-error":
-				return nil, ErrCacheTest
-			case "cache-write-error":
-				return nil, hord.ErrNil
-			case "database-error":
-				return nil, hord.ErrNil
-			}
-			return nil, errors.New("Unexpected Cache Error")
-		},
-		SetFunc: func(key string, _ []byte) error {
-			if key == "cache-write-error" {
-				return ErrCacheTest
-			}
-			return nil
-		},
-	}
-	databaseConfig := mock.Config{
-		GetFunc: func(key string) ([]byte, error) {
-			switch key {
-			case "cache-hit":
-				return nil, errors.New("Expected Cache Hit")
-			case "cache-miss":
-				return []byte("database-data"), nil
-			case "cache-error":
-				return nil, errors.New("Expected Cache Error")
-			case "cache-write-error":
-				return nil, nil
-			case "database-error":
-				return nil, ErrDatabaseTest
-			}
-			return nil, errors.New("Unexpected Database Error")
-		},
-	}
-
-	unitTests := map[string]struct {
-		key           string
-		expectedError error
-		expectedData  []byte
-	}{
-		"Cache Hit": {
-			key:           "cache-hit",
-			expectedError: nil,
-			expectedData:  []byte("cache-data"),
-		},
-		"Cache Miss": {
-			key:           "cache-miss",
-			expectedError: nil,
-			expectedData:  []byte("database-data"),
-		},
-		"Cache Error": {
-			key:           "cache-error",
-			expectedError: ErrCacheTest,
-			expectedData:  nil,
-		},
-		"Cache Write Error": {
-			key:           "cache-write-error",
-			expectedError: ErrCacheTest,
-			expectedData:  nil,
-		},
-		"Database Error": {
-			key:           "database-error",
-			expectedError: ErrDatabaseTest,
-			expectedData:  nil,
-		},
-	}
-
-	for name, test := range unitTests {
-		t.Run(name, func(t *testing.T) {
-			db, err := setupCache(cacheConfig, databaseConfig)
-			if err != nil {
-				t.Fatalf("Failed to connect to database - %s", err)
-			}
-
-			data, err := db.Get(test.key)
-			if !errors.Is(err, test.expectedError) {
-				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
-			}
-			if string(data) != string(test.expectedData) {
-				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, data, test.expectedData)
-			}
-		})
-	}
-}
-
-func TestSet(t *testing.T) {
-	cacheValue := []byte("")
-	databaseValue := []byte("")
-
-	cacheConfig := mock.Config{
-		SetFunc: func(key string, data []byte) error {
-			cacheValue = nil
-			switch key {
-			case "happy-path":
-				cacheValue = data
-				return nil
-			case "cache-error":
-				return ErrCacheTest
-			case "database-error":
-				cacheValue = data
-				return nil
-			}
-			return errors.New("Unexpected Cache Error")
-		},
-	}
-	databaseConfig := mock.Config{
-		SetFunc: func(key string, data []byte) error {
-			databaseValue = nil
-			switch key {
-			case "happy-path":
-				databaseValue = data
-				return nil
-			case "cache-error":
-				databaseValue = data
-				return nil
-			case "database-error":
-				return ErrDatabaseTest
-			}
-			return errors.New("Unexpected Database Error")
-		},
-	}
-
-	unitTests := map[string]struct {
-		key                   string
-		data                  []byte
-		expectedError         error
-		expectedCacheValue    []byte
-		expectedDatabaseValue []byte
-	}{
-		"Cache Error": {
-			key:                   "cache-error",
-			data:                  []byte("cache-error-data"),
-			expectedError:         ErrCacheTest,
-			expectedCacheValue:    nil,
-			expectedDatabaseValue: []byte("cache-error-data"),
-		},
-		"Database Error": {
-			key:                   "database-error",
-			data:                  []byte("database-error-data"),
-			expectedError:         ErrDatabaseTest,
-			expectedCacheValue:    nil,
-			expectedDatabaseValue: nil,
-		},
-		"Happy Path": {
-			key:                   "happy-path",
-			data:                  []byte("happy-path-data"),
-			expectedError:         nil,
-			expectedCacheValue:    []byte("happy-path-data"),
-			expectedDatabaseValue: []byte("happy-path-data"),
-		},
-	}
-
-	for name, test := range unitTests {
-		t.Run(name, func(t *testing.T) {
-			db, err := setupCache(cacheConfig, databaseConfig)
-			if err != nil {
-				t.Fatalf("Failed to connect to database - %s", err)
-			}
-
-			err = db.Set(test.key, test.data)
-			if !errors.Is(err, test.expectedError) {
-				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
-			}
-			if !bytes.Equal(cacheValue, test.expectedCacheValue) {
-				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, cacheValue, test.expectedCacheValue)
-			}
-			if !bytes.Equal(databaseValue, test.expectedDatabaseValue) {
-				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, databaseValue, test.expectedDatabaseValue)
-			}
-		})
-	}
-}
-
-func TestDelete(t *testing.T) {
-	cacheConfig := mock.Config{
-		DeleteFunc: func(key string) error {
-			switch key {
-			case "happy-path":
-				return nil
-			case "cache-error":
-				return ErrCacheTest
-			case "database-error":
-				return nil
-			}
-			return errors.New("Unexpected Cache Error")
-		},
-	}
-	databaseConfig := mock.Config{
-		DeleteFunc: func(key string) error {
-			switch key {
-			case "happy-path":
-				return nil
-			case "cache-error":
-				return nil
-			case "database-error":
-				return ErrDatabaseTest
-			}
-			return errors.New("Unexpected Database Error")
-		},
-	}
-
-	unitTests := map[string]struct {
-		key           string
-		expectedError error
-	}{
-		"Cache Error": {
-			key:           "cache-error",
-			expectedError: ErrCacheTest,
-		},
-		"Database Error": {
-			key:           "database-error",
-			expectedError: ErrDatabaseTest,
-		},
-		"Happy Path": {
-			key:           "happy-path",
-			expectedError: nil,
-		},
-	}
-
-	for name, test := range unitTests {
-		t.Run(name, func(t *testing.T) {
-			db, err := setupCache(cacheConfig, databaseConfig)
-			if err != nil {
-				t.Fatalf("Failed to connect to database - %s", err)
-			}
-
-			err = db.Delete(test.key)
-			if !errors.Is(err, test.expectedError) {
-				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
-			}
-		})
-	}
-}
-
-func TestKeys(t *testing.T) {
-	databaseConfig := mock.Config{
-		KeysFunc: func() ([]string, error) {
-			return []string{"database-key"}, nil
-		},
-	}
-	cacheConfig := mock.Config{
-		KeysFunc: func() ([]string, error) {
-			return []string{"cache-key"}, nil
-		},
-	}
-
-	db, err := setupCache(cacheConfig, databaseConfig)
-	if err != nil {
-		t.Fatalf("Failed to connect to database - %s", err)
-	}
-
-	keys, err := db.Keys()
-	if err != nil {
-		t.Errorf("Keys() returned error: %s", err)
-	}
-	if keys[0] != "database-key" {
-		t.Errorf("Keys() returned data: %v, expected %v", keys, []string{"database-key"})
-	}
-}
-
-func TestClose(t *testing.T) {
-	databaseConfig := mock.Config{}
-	cacheConfig := mock.Config{}
-
-	db, err := setupCache(cacheConfig, databaseConfig)
-	if err != nil {
-		t.Fatalf("Failed to connect to database - %s", err)
-	}
-
-	db.Close()
 }

--- a/drivers/cache/cache_test.go
+++ b/drivers/cache/cache_test.go
@@ -35,7 +35,7 @@ func TestDial(t *testing.T) {
 				Database:  &mock.Database{},
 				Cache:     &mock.Database{},
 			},
-			expectedError: nil,
+			expectedError: ErrNoType,
 		},
 		"Type: Lookaside": {
 			config: Config{

--- a/drivers/cache/cache_test.go
+++ b/drivers/cache/cache_test.go
@@ -191,10 +191,18 @@ func TestGet(t *testing.T) {
 				return nil, hord.ErrNil
 			case "cache-error":
 				return nil, ErrCacheTest
+			case "cache-write-error":
+				return nil, hord.ErrNil
 			case "database-error":
 				return nil, hord.ErrNil
 			}
 			return nil, errors.New("Unexpected Cache Error")
+		},
+		SetFunc: func(key string, data []byte) error {
+			if key == "cache-write-error" {
+				return ErrCacheTest
+			}
+			return nil
 		},
 	}
 	databaseConfig := mock.Config{
@@ -206,6 +214,8 @@ func TestGet(t *testing.T) {
 				return []byte("database-data"), nil
 			case "cache-error":
 				return nil, errors.New("Expected Cache Error")
+			case "cache-write-error":
+				return nil, nil
 			case "database-error":
 				return nil, ErrDatabaseTest
 			}
@@ -230,6 +240,11 @@ func TestGet(t *testing.T) {
 		},
 		"Cache Error": {
 			key:           "cache-error",
+			expectedError: ErrCacheTest,
+			expectedData:  nil,
+		},
+		"Cache Write Error": {
+			key:           "cache-write-error",
 			expectedError: ErrCacheTest,
 			expectedData:  nil,
 		},

--- a/drivers/cache/cache_test.go
+++ b/drivers/cache/cache_test.go
@@ -198,7 +198,7 @@ func TestGet(t *testing.T) {
 			}
 			return nil, errors.New("Unexpected Cache Error")
 		},
-		SetFunc: func(key string, data []byte) error {
+		SetFunc: func(key string, _ []byte) error {
 			if key == "cache-write-error" {
 				return ErrCacheTest
 			}

--- a/drivers/cache/cache_test.go
+++ b/drivers/cache/cache_test.go
@@ -31,17 +31,17 @@ func TestDial(t *testing.T) {
 		},
 		"Invalid Type": {
 			config: Config{
-				CacheType: "invalid",
-				Database:  &mock.Database{},
-				Cache:     &mock.Database{},
+				Type:     "invalid",
+				Database: &mock.Database{},
+				Cache:    &mock.Database{},
 			},
 			expectedError: ErrNoType,
 		},
 		"Type: Lookaside": {
 			config: Config{
-				CacheType: Lookaside,
-				Database:  &mock.Database{},
-				Cache:     &mock.Database{},
+				Type:     Lookaside,
+				Database: &mock.Database{},
+				Cache:    &mock.Database{},
 			},
 			expectedError: nil,
 		},

--- a/drivers/cache/cache_test.go
+++ b/drivers/cache/cache_test.go
@@ -1,0 +1,446 @@
+package cache
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/madflojo/hord"
+	"github.com/madflojo/hord/drivers/mock"
+)
+
+// Test Errors used for testing purposes
+var (
+	ErrDatabaseTest = errors.New("database error")
+	ErrCacheTest    = errors.New("cache error")
+)
+
+// setupCache is a helper function to create a new Cache driver using the provided database and cache Config.
+func setupCache(cacheConfig mock.Config, databaseConfig mock.Config) (*Cache, error) {
+	database, err := mock.Dial(databaseConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	cache, err := mock.Dial(cacheConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return Dial(Config{
+		Database: database,
+		Cache:    cache,
+	})
+}
+
+func TestDial(t *testing.T) {
+	unitTests := map[string]struct {
+		config        Config
+		expectedError error
+	}{
+		"No Config": {
+			config:        Config{},
+			expectedError: ErrInvalidDatabase,
+		},
+		"No Database": {
+			config: Config{
+				Cache: &mock.Database{},
+			},
+			expectedError: ErrInvalidDatabase,
+		},
+		"No Cache": {
+			config: Config{
+				Database: &mock.Database{},
+			},
+			expectedError: ErrInvalidCache,
+		},
+		"Happy Path": {
+			config: Config{
+				Database: &mock.Database{},
+				Cache:    &mock.Database{},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			_, err := Dial(test.config)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Dial(%v) returned error: %s, expected %s", test.config, err, test.expectedError)
+			}
+		})
+	}
+}
+
+func TestSetup(t *testing.T) {
+	unitTests := map[string]struct {
+		databaseError error
+		cacheError    error
+		expectedError error
+	}{
+		"Database Error": {
+			databaseError: ErrDatabaseTest,
+			cacheError:    nil,
+			expectedError: ErrDatabaseTest,
+		},
+		"Cache Error": {
+			databaseError: nil,
+			cacheError:    ErrCacheTest,
+			expectedError: ErrCacheTest,
+		},
+		"Both Errors": {
+			databaseError: ErrDatabaseTest,
+			cacheError:    ErrCacheTest,
+			expectedError: ErrDatabaseTest,
+		},
+		"Happy Path": {
+			databaseError: nil,
+			cacheError:    nil,
+			expectedError: nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			databaseConfig := mock.Config{
+				SetupFunc: func() error {
+					return test.databaseError
+				},
+			}
+			cacheConfig := mock.Config{
+				SetupFunc: func() error {
+					return test.cacheError
+				},
+			}
+
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			err = db.Setup()
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Setup() returned error: %s, expected %s", err, test.expectedError)
+			}
+		})
+	}
+}
+
+func TestHealthCheck(t *testing.T) {
+	unitTests := map[string]struct {
+		databaseError error
+		cacheError    error
+		expectedError error
+	}{
+		"Database Error": {
+			databaseError: ErrDatabaseTest,
+			cacheError:    nil,
+			expectedError: ErrDatabaseTest,
+		},
+		"Cache Error": {
+			databaseError: nil,
+			cacheError:    ErrCacheTest,
+			expectedError: ErrCacheTest,
+		},
+		"Both Errors": {
+			databaseError: ErrDatabaseTest,
+			cacheError:    ErrCacheTest,
+			expectedError: ErrDatabaseTest,
+		},
+		"Happy Path": {
+			databaseError: nil,
+			cacheError:    nil,
+			expectedError: nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			databaseConfig := mock.Config{
+				HealthCheckFunc: func() error {
+					return test.databaseError
+				},
+			}
+			cacheConfig := mock.Config{
+				HealthCheckFunc: func() error {
+					return test.cacheError
+				},
+			}
+
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			err = db.HealthCheck()
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("HealthCheck() returned error: %s, expected %s", err, test.expectedError)
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	cacheConfig := mock.Config{
+		GetFunc: func(key string) ([]byte, error) {
+			switch key {
+			case "cache-hit":
+				return []byte("cache-data"), nil
+			case "cache-miss":
+				return nil, hord.ErrNil
+			case "cache-error":
+				return nil, ErrCacheTest
+			case "database-error":
+				return nil, hord.ErrNil
+			}
+			return nil, errors.New("Unexpected Cache Error")
+		},
+	}
+	databaseConfig := mock.Config{
+		GetFunc: func(key string) ([]byte, error) {
+			switch key {
+			case "cache-hit":
+				return nil, errors.New("Expected Cache Hit")
+			case "cache-miss":
+				return []byte("database-data"), nil
+			case "cache-error":
+				return nil, errors.New("Expected Cache Error")
+			case "database-error":
+				return nil, ErrDatabaseTest
+			}
+			return nil, errors.New("Unexpected Database Error")
+		},
+	}
+
+	unitTests := map[string]struct {
+		key           string
+		expectedError error
+		expectedData  []byte
+	}{
+		"Cache Hit": {
+			key:           "cache-hit",
+			expectedError: nil,
+			expectedData:  []byte("cache-data"),
+		},
+		"Cache Miss": {
+			key:           "cache-miss",
+			expectedError: nil,
+			expectedData:  []byte("database-data"),
+		},
+		"Cache Error": {
+			key:           "cache-error",
+			expectedError: ErrCacheTest,
+			expectedData:  nil,
+		},
+		"Database Error": {
+			key:           "database-error",
+			expectedError: ErrDatabaseTest,
+			expectedData:  nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			data, err := db.Get(test.key)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
+			}
+			if string(data) != string(test.expectedData) {
+				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, data, test.expectedData)
+			}
+		})
+	}
+}
+
+func TestSet(t *testing.T) {
+	cacheValue := []byte("")
+	databaseValue := []byte("")
+
+	cacheConfig := mock.Config{
+		SetFunc: func(key string, data []byte) error {
+			cacheValue = nil
+			switch key {
+			case "happy-path":
+				cacheValue = data
+				return nil
+			case "cache-error":
+				return ErrCacheTest
+			case "database-error":
+				cacheValue = data
+				return nil
+			}
+			return errors.New("Unexpected Cache Error")
+		},
+	}
+	databaseConfig := mock.Config{
+		SetFunc: func(key string, data []byte) error {
+			databaseValue = nil
+			switch key {
+			case "happy-path":
+				databaseValue = data
+				return nil
+			case "cache-error":
+				databaseValue = data
+				return nil
+			case "database-error":
+				return ErrDatabaseTest
+			}
+			return errors.New("Unexpected Database Error")
+		},
+	}
+
+	unitTests := map[string]struct {
+		key                   string
+		data                  []byte
+		expectedError         error
+		expectedCacheValue    []byte
+		expectedDatabaseValue []byte
+	}{
+		"Cache Error": {
+			key:                   "cache-error",
+			data:                  []byte("cache-error-data"),
+			expectedError:         ErrCacheTest,
+			expectedCacheValue:    nil,
+			expectedDatabaseValue: []byte("cache-error-data"),
+		},
+		"Database Error": {
+			key:                   "database-error",
+			data:                  []byte("database-error-data"),
+			expectedError:         ErrDatabaseTest,
+			expectedCacheValue:    nil,
+			expectedDatabaseValue: nil,
+		},
+		"Happy Path": {
+			key:                   "happy-path",
+			data:                  []byte("happy-path-data"),
+			expectedError:         nil,
+			expectedCacheValue:    []byte("happy-path-data"),
+			expectedDatabaseValue: []byte("happy-path-data"),
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			err = db.Set(test.key, test.data)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
+			}
+			if !bytes.Equal(cacheValue, test.expectedCacheValue) {
+				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, cacheValue, test.expectedCacheValue)
+			}
+			if !bytes.Equal(databaseValue, test.expectedDatabaseValue) {
+				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, databaseValue, test.expectedDatabaseValue)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	cacheConfig := mock.Config{
+		DeleteFunc: func(key string) error {
+			switch key {
+			case "happy-path":
+				return nil
+			case "cache-error":
+				return ErrCacheTest
+			case "database-error":
+				return nil
+			}
+			return errors.New("Unexpected Cache Error")
+		},
+	}
+	databaseConfig := mock.Config{
+		DeleteFunc: func(key string) error {
+			switch key {
+			case "happy-path":
+				return nil
+			case "cache-error":
+				return nil
+			case "database-error":
+				return ErrDatabaseTest
+			}
+			return errors.New("Unexpected Database Error")
+		},
+	}
+
+	unitTests := map[string]struct {
+		key           string
+		expectedError error
+	}{
+		"Cache Error": {
+			key:           "cache-error",
+			expectedError: ErrCacheTest,
+		},
+		"Database Error": {
+			key:           "database-error",
+			expectedError: ErrDatabaseTest,
+		},
+		"Happy Path": {
+			key:           "happy-path",
+			expectedError: nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			err = db.Delete(test.key)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
+			}
+		})
+	}
+}
+
+func TestKeys(t *testing.T) {
+	databaseConfig := mock.Config{
+		KeysFunc: func() ([]string, error) {
+			return []string{"database-key"}, nil
+		},
+	}
+	cacheConfig := mock.Config{
+		KeysFunc: func() ([]string, error) {
+			return []string{"cache-key"}, nil
+		},
+	}
+
+	db, err := setupCache(cacheConfig, databaseConfig)
+	if err != nil {
+		t.Fatalf("Failed to connect to database - %s", err)
+	}
+
+	keys, err := db.Keys()
+	if err != nil {
+		t.Errorf("Keys() returned error: %s", err)
+	}
+	if keys[0] != "database-key" {
+		t.Errorf("Keys() returned data: %v, expected %v", keys, []string{"database-key"})
+	}
+}
+
+func TestClose(t *testing.T) {
+	databaseConfig := mock.Config{}
+	cacheConfig := mock.Config{}
+
+	db, err := setupCache(cacheConfig, databaseConfig)
+	if err != nil {
+		t.Fatalf("Failed to connect to database - %s", err)
+	}
+
+	db.Close()
+}

--- a/drivers/cache/common_test.go
+++ b/drivers/cache/common_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/madflojo/hord"
 	"github.com/madflojo/hord/drivers/cassandra"
 	"github.com/madflojo/hord/drivers/hashmap"
-	"github.com/madflojo/hord/drivers/mock"
 	"github.com/madflojo/hord/drivers/redis"
 )
 
@@ -308,17 +307,15 @@ func TestInterfaceHappyPath(t *testing.T) {
 
 func TestInterfaceFail(t *testing.T) {
 	// Setup Redis, Cassandra Test Databases
-	redis := mock.Database{}
-	// redis, err := DialFromName("redis")
-	// if err != nil {
-	// 	t.Fatalf("Failed to connect to Redis - %s", err)
-	// }
+	redis, err := DialFromName("redis")
+	if err != nil {
+		t.Fatalf("Failed to connect to Redis - %s", err)
+	}
 
-	cass := mock.Database{}
-	// cass, err := DialFromName("cassandra")
-	// if err != nil {
-	// 	t.Fatalf("Failed to connect to Cassandra - %s", err)
-	// }
+	cass, err := DialFromName("cassandra")
+	if err != nil {
+		t.Fatalf("Failed to connect to Cassandra - %s", err)
+	}
 
 	// Setup Invalid Configurations
 	cfgs := make(map[string]Config)

--- a/drivers/cache/common_test.go
+++ b/drivers/cache/common_test.go
@@ -34,16 +34,19 @@ func TestInterfaceHappyPath(t *testing.T) {
 
 	// Setup Configurations
 	cfgs := map[string]struct {
-		cacheType string
-		dbType    string
+		cacheType   string
+		dbType      string
+		cacheMethod Type
 	}{
 		"Redis + Cassandra": {
-			cacheType: "redis",
-			dbType:    "cassandra",
+			cacheType:   "redis",
+			dbType:      "cassandra",
+			cacheMethod: Lookaside,
 		},
 		"Redis + Hashmap": {
-			cacheType: "redis",
-			dbType:    "hashmap",
+			cacheType:   "redis",
+			dbType:      "hashmap",
+			cacheMethod: Lookaside,
 		},
 	}
 
@@ -63,8 +66,9 @@ func TestInterfaceHappyPath(t *testing.T) {
 
 			// Establish Connectivity
 			db, err := Dial(Config{
-				Cache:    cache,
-				Database: database,
+				Cache:     cache,
+				Database:  database,
+				CacheType: cfg.cacheMethod,
 			})
 			if err != nil {
 				t.Fatalf("Failed to connect to database - %s", err)
@@ -316,10 +320,17 @@ func TestInterfaceFail(t *testing.T) {
 	// Setup Invalid Configurations
 	cfgs := make(map[string]Config)
 	cfgs["Missing Cache"] = Config{
-		Database: cass,
+		Database:  cass,
+		CacheType: Lookaside,
 	}
 	cfgs["Missing Database"] = Config{
-		Cache: redis,
+		Cache:     redis,
+		CacheType: Lookaside,
+	}
+	cfgs["Invalid Type"] = Config{
+		Cache:     redis,
+		Database:  cass,
+		CacheType: "invalid",
 	}
 
 	// Loop through invalid Configs and validate the driver reacts appropriately

--- a/drivers/cache/common_test.go
+++ b/drivers/cache/common_test.go
@@ -1,0 +1,398 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/madflojo/hord"
+	"github.com/madflojo/hord/drivers/cassandra"
+	"github.com/madflojo/hord/drivers/hashmap"
+	"github.com/madflojo/hord/drivers/redis"
+)
+
+func DialFromName(name string) (hord.Database, error) {
+	switch name {
+	case "cassandra":
+		return cassandra.Dial(cassandra.Config{
+			Hosts:    []string{"cassandra-primary", "cassandra"},
+			Keyspace: "hord",
+		})
+	case "hashmap":
+		return hashmap.Dial(hashmap.Config{})
+	case "redis":
+		return redis.Dial(redis.Config{
+			ConnectTimeout: time.Duration(5) * time.Second,
+			Server:         "redis:6379",
+		})
+	default:
+		return nil, fmt.Errorf("Unknown Database Type")
+	}
+}
+
+func TestInterfaceHappyPath(t *testing.T) {
+
+	// Setup Configurations
+	cfgs := map[string]struct {
+		cacheType string
+		dbType    string
+	}{
+		"Redis + Cassandra": {
+			cacheType: "redis",
+			dbType:    "cassandra",
+		},
+		"Redis + Hashmap": {
+			cacheType: "redis",
+			dbType:    "hashmap",
+		},
+	}
+
+	// Loop through valid Configs and validate the driver adheres to the Hord interface
+	for name, cfg := range cfgs {
+		t.Run(name, func(t *testing.T) {
+			// Dial Dependent Databases
+			cache, err := DialFromName(cfg.cacheType)
+			if err != nil {
+				t.Fatalf("Failed to connect to cache - %s", err)
+			}
+
+			database, err := DialFromName(cfg.dbType)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			// Establish Connectivity
+			db, err := Dial(Config{
+				Cache:    cache,
+				Database: database,
+			})
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+			defer db.Close()
+
+			// Setup Database
+			t.Run("Setup Database", func(t *testing.T) {
+				err := db.Setup()
+				if err != nil {
+					t.Errorf("Failed to execute Setup - %s", err)
+				}
+				<-time.After(1 * time.Second)
+			})
+
+			// Perform HealthCheck
+			t.Run("Validate Database Health", func(t *testing.T) {
+				err = db.HealthCheck()
+				if err != nil {
+					t.Fatalf("Unexpected error when performing health check - %s", err)
+				}
+			})
+
+			// Single Key Execution
+			t.Run("Single Key Execution", func(t *testing.T) {
+
+				// Clear Database when done
+				t.Cleanup(func() {
+					keys, err := db.Keys()
+					if err != nil {
+						t.Fatalf("Unexpected error when obtaining a list of keys from the Redis - %s", err)
+					}
+
+					for _, k := range keys {
+						_ = db.Delete(k)
+					}
+				})
+
+				// No Keys
+				t.Run("No Keys", func(t *testing.T) {
+					keys, err := db.Keys()
+					if err != nil {
+						t.Fatalf("Unexpected error when obtaining a list of keys from the Redis - %s", err)
+					}
+
+					if len(keys) > 0 {
+						t.Fatalf("Unexpected keys found in key list got - %+v", keys)
+					}
+				})
+
+				// Get a Missing Key
+				t.Run("Get Missing Key", func(t *testing.T) {
+					_, err := db.Get("404notfound")
+					if err == nil && err != hord.ErrNil {
+						t.Errorf("Expected ErrNil when looking up nonexistent key - %s", err)
+					}
+				})
+
+				// Delete a Missing Key
+				t.Run("Delete Missing Key", func(t *testing.T) {
+					err := db.Delete("404notfound")
+					if err != nil {
+						t.Errorf("Expected nil when deleting nonexistent key - %s", err)
+					}
+				})
+
+				// Set a Key
+				t.Run("Set a Key", func(t *testing.T) {
+					err := db.Set("test_key", []byte("Testing"))
+					if err != nil {
+						t.Errorf("Unexpected error when writing data - %s", err)
+					}
+				})
+
+				// Get a Key
+				t.Run("Get a Key", func(t *testing.T) {
+					data, err := db.Get("test_key")
+					if err != nil {
+						t.Fatalf("Unexpected error when reading data - %s", err)
+					}
+
+					if string(data) != "Testing" {
+						t.Errorf("Data mismatch from previously set data and fetched data got %+v expected %+v", data, []byte("Testing"))
+					}
+				})
+
+				// Get list of Keys
+				t.Run("Get a list of Keys", func(t *testing.T) {
+					keys, err := db.Keys()
+					if err != nil {
+						t.Fatalf("Unexpected error when fetching keys - %s", err)
+					}
+
+					if len(keys) != 1 {
+						t.Errorf("Unexpected number of returned keys - got %d, expected 1", len(keys))
+					}
+				})
+
+				// Delete a Key
+				t.Run("Delete a Key", func(t *testing.T) {
+					err := db.Delete("test_key")
+					if err != nil {
+						t.Fatalf("Unexpected error when deleting data - %s", err)
+					}
+
+					data, err := db.Get("test_key")
+					if err != hord.ErrNil && len(data) != 0 {
+						t.Errorf("It does not appear data was completely deleted - %+v", data)
+					}
+				})
+
+				// Set a Invalid Key
+				t.Run("Set a Invalid Key", func(t *testing.T) {
+					err := db.Set("", []byte("Testing"))
+					if err == nil || err != hord.ErrInvalidKey {
+						t.Errorf("Expected ErrInvalidKey when using blank key")
+					}
+				})
+
+				// Get a Invalid Key
+				t.Run("Get a Invalid Key", func(t *testing.T) {
+					_, err := db.Get("")
+					if err == nil || err != hord.ErrInvalidKey {
+						t.Errorf("Expected ErrInvalidKey when using blank key")
+					}
+				})
+
+				// Delete a Invalid Key
+				t.Run("Delete a Invalid Key", func(t *testing.T) {
+					err := db.Delete("")
+					if err == nil || err != hord.ErrInvalidKey {
+						t.Errorf("Expected ErrInvalidKey when using blank key")
+					}
+				})
+
+				// Set with Invalid Data
+				t.Run("Set with Invalid Data", func(t *testing.T) {
+					err := db.Set("test_key", []byte(""))
+					if err == nil || err != hord.ErrInvalidData {
+						t.Errorf("Expected ErrInvalidData when using blank data")
+					}
+				})
+
+			})
+
+			// Lots of Keys Execution
+			t.Run("Multiple Key Execution", func(t *testing.T) {
+				// Clear Database when done
+				t.Cleanup(func() {
+					keys, err := db.Keys()
+					if err != nil {
+						t.Fatalf("Unexecpted error when obtaining a list of keys from the Redis - %s", err)
+					}
+
+					for _, k := range keys {
+						_ = db.Delete(k)
+					}
+				})
+
+				// Create a ton of keys
+				t.Run("Create 10 keys", func(t *testing.T) {
+					for i := 0; i < 10; i++ {
+						err := db.Set(fmt.Sprintf("Testing 1000 keys with key number %d", i), []byte("Testing"))
+						if err != nil {
+							t.Fatalf("Error setting up test keys - %s", err)
+						}
+					}
+				})
+
+				// Count Keys
+				t.Run("Ensure 10 keys exist", func(t *testing.T) {
+					keys, err := db.Keys()
+					if err != nil {
+						t.Fatalf("Error fetcing keys from database - %s", err)
+					}
+
+					if len(keys) != 10 {
+						t.Errorf("Invalid Number of Keys returned %d", len(keys))
+					}
+				})
+
+			})
+
+			t.Run("Closed DB Execution", func(t *testing.T) {
+
+				db.Close()
+
+				// Perform HealthCheck
+				t.Run("Validate Database Health", func(t *testing.T) {
+					err = db.HealthCheck()
+					if err == nil {
+						t.Errorf("Unexpected success when performing task on closed database - %s", err)
+					}
+				})
+
+				// Single Key Execution
+				t.Run("Single Key Execution", func(t *testing.T) {
+					// Set a Key
+					t.Run("Set a Key", func(t *testing.T) {
+						err := db.Set("test_key", []byte("Testing"))
+						if err == nil {
+							t.Errorf("Unexpected success when performing task on closed database - %s", err)
+						}
+					})
+
+					// Get a Key
+					t.Run("Get a Key", func(t *testing.T) {
+						_, err := db.Get("test_key")
+						if err == nil {
+							t.Errorf("Unexpected success when performing task on closed database - %s", err)
+						}
+					})
+
+					// Get list of Keys
+					t.Run("Get a list of Keys", func(t *testing.T) {
+						_, err := db.Keys()
+						if err == nil {
+							t.Errorf("Unexpected success when performing task on closed database - %s", err)
+						}
+					})
+
+					// Delete a Key
+					t.Run("Delete a Key", func(t *testing.T) {
+						err := db.Delete("test_key")
+						if err == nil {
+							t.Errorf("Unexpected success when performing task on closed database - %s", err)
+						}
+					})
+
+				})
+			})
+
+		})
+	}
+}
+
+func TestInterfaceFail(t *testing.T) {
+	// Setup Redis, Cassandra Test Databases
+	redis, err := DialFromName("redis")
+	if err != nil {
+		t.Fatalf("Failed to connect to Redis - %s", err)
+	}
+
+	cass, err := DialFromName("cassandra")
+	if err != nil {
+		t.Fatalf("Failed to connect to Cassandra - %s", err)
+	}
+
+	// Setup Invalid Configurations
+	cfgs := make(map[string]Config)
+	cfgs["Missing Cache"] = Config{
+		Database: cass,
+	}
+	cfgs["Missing Database"] = Config{
+		Cache: redis,
+	}
+
+	// Loop through invalid Configs and validate the driver reacts appropriately
+	for name, cfg := range cfgs {
+		t.Run(name, func(t *testing.T) {
+			// Establish Connectivity
+			db, err := Dial(cfg)
+			if err == nil {
+				t.Errorf("Expected error when connecting to database but got no error...")
+			}
+			defer db.Close()
+
+			// Setup Database
+			t.Run("Setup Database", func(t *testing.T) {
+				err := db.Setup()
+				if err == nil {
+					t.Errorf("Expected error when attempting to setup database without connection...")
+				}
+			})
+
+			// Perform HealthCheck
+			t.Run("Validate Database Health", func(t *testing.T) {
+				err = db.HealthCheck()
+				if err == nil {
+					t.Errorf("Expected error when attempting to healthcheck database without connection...")
+				}
+			})
+
+			// Single Key Execution
+			t.Run("Single Key Execution", func(t *testing.T) {
+
+				// Clear Database when done
+				t.Cleanup(func() {
+					keys, _ := db.Keys()
+					for _, k := range keys {
+						_ = db.Delete(k)
+					}
+				})
+
+				// Set a Key
+				t.Run("Set a Key", func(t *testing.T) {
+					err := db.Set("test_key", []byte("Testing"))
+					if err == nil {
+						t.Errorf("Expected error when using data with no connection...")
+					}
+				})
+				// Get a Key
+				t.Run("Get a Key", func(t *testing.T) {
+					_, err := db.Get("test_key")
+					if err == nil {
+						t.Errorf("Expected error when using data with no connection...")
+					}
+				})
+
+				// Get list of Keys
+				t.Run("Get a list of Keys", func(t *testing.T) {
+					keys, err := db.Keys()
+					if err == nil {
+						t.Errorf("Expected error when using data with no connection...")
+					}
+					if len(keys) != 0 {
+						t.Errorf("Unexpected number of returned keys - got %d, expected 0", len(keys))
+					}
+				})
+
+				// Delete a Key
+				t.Run("Delete a Key", func(t *testing.T) {
+					err := db.Delete("test_key")
+					if err == nil {
+						t.Errorf("Expected error when using data with no connection...")
+					}
+				})
+			})
+		})
+	}
+}

--- a/drivers/cache/common_test.go
+++ b/drivers/cache/common_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/madflojo/hord"
 	"github.com/madflojo/hord/drivers/cassandra"
 	"github.com/madflojo/hord/drivers/hashmap"
+	"github.com/madflojo/hord/drivers/mock"
 	"github.com/madflojo/hord/drivers/redis"
 )
 
@@ -66,9 +67,9 @@ func TestInterfaceHappyPath(t *testing.T) {
 
 			// Establish Connectivity
 			db, err := Dial(Config{
-				Cache:     cache,
-				Database:  database,
-				CacheType: cfg.cacheMethod,
+				Cache:    cache,
+				Database: database,
+				Type:     cfg.cacheMethod,
 			})
 			if err != nil {
 				t.Fatalf("Failed to connect to database - %s", err)
@@ -307,30 +308,32 @@ func TestInterfaceHappyPath(t *testing.T) {
 
 func TestInterfaceFail(t *testing.T) {
 	// Setup Redis, Cassandra Test Databases
-	redis, err := DialFromName("redis")
-	if err != nil {
-		t.Fatalf("Failed to connect to Redis - %s", err)
-	}
+	redis := mock.Database{}
+	// redis, err := DialFromName("redis")
+	// if err != nil {
+	// 	t.Fatalf("Failed to connect to Redis - %s", err)
+	// }
 
-	cass, err := DialFromName("cassandra")
-	if err != nil {
-		t.Fatalf("Failed to connect to Cassandra - %s", err)
-	}
+	cass := mock.Database{}
+	// cass, err := DialFromName("cassandra")
+	// if err != nil {
+	// 	t.Fatalf("Failed to connect to Cassandra - %s", err)
+	// }
 
 	// Setup Invalid Configurations
 	cfgs := make(map[string]Config)
 	cfgs["Missing Cache"] = Config{
-		Database:  cass,
-		CacheType: Lookaside,
+		Database: cass,
+		Type:     Lookaside,
 	}
 	cfgs["Missing Database"] = Config{
-		Cache:     redis,
-		CacheType: Lookaside,
+		Cache: redis,
+		Type:  Lookaside,
 	}
 	cfgs["Invalid Type"] = Config{
-		Cache:     redis,
-		Database:  cass,
-		CacheType: "invalid",
+		Cache:    redis,
+		Database: cass,
+		Type:     "invalid",
 	}
 
 	// Loop through invalid Configs and validate the driver reacts appropriately

--- a/drivers/cache/lookaside/lookaside.go
+++ b/drivers/cache/lookaside/lookaside.go
@@ -114,7 +114,7 @@ func Dial(cfg Config) (hord.Database, error) {
 
 // Setup will run the Setup function for both the database and the cache.
 func (db *Lookaside) Setup() error {
-	if db == nil || db.data == nil || db.cache == nil {
+	if db.data == nil || db.cache == nil {
 		return hord.ErrNoDial
 	}
 

--- a/drivers/cache/lookaside/lookaside.go
+++ b/drivers/cache/lookaside/lookaside.go
@@ -1,0 +1,231 @@
+/*
+Package lookaside provides a Hord database driver for a look-aside cache. To use this driver, import it as follows:
+
+	import (
+	    "github.com/madflojo/hord"
+	    "github.com/madflojo/hord/cache/lookaside"
+	)
+
+# Connecting to the Database
+
+Use the Dial() function to create a new client for interacting with the cache.
+
+	// Handle database connection
+	var database hord.Database
+	...
+
+	// Handle cache connection
+	var cache hord.Database
+	...
+
+	var db hord.Database
+	db, err := lookaside.Dial(lookaside.Config{
+		Database: database,
+		Cache: 	  cache,
+	})
+	if err != nil {
+	    // Handle connection error
+	}
+
+# Initialize database
+
+Hord provides a Setup() function for preparing a database. This function is safe to execute after every Dial().
+
+	err := db.Setup()
+	if err != nil {
+	    // Handle setup error
+	}
+
+# Database Operations
+
+Hord provides a simple abstraction for working with the cache, with easy-to-use methods such as Get() and Set() to read and write values.
+
+	// Handle database connection
+	var database hord.Database
+	database, err := cassandra.Dial(cassandra.Config{})
+	if err != nil {
+		// Handle connection error
+	}
+
+	// Handle cache connection
+	var cache hord.Database
+	cache, err := redis.Dial(redis.Config{})
+	if err != nil {
+		// Handle connection error
+	}
+
+	// Connect to the Cache database
+	db, err := lookaside.Dial(lookaside.Config{
+		Database: database,
+		Cache: 	  cache,
+	})
+	if err != nil {
+	    // Handle connection error
+	}
+
+	err := db.Setup()
+	if err != nil {
+	    // Handle setup error
+	}
+
+	// Set a value
+	err = db.Set("key", []byte("value"))
+	if err != nil {
+	    // Handle error
+	}
+
+	// Retrieve a value
+	value, err := db.Get("key")
+	if err != nil {
+	    // Handle error
+	}
+*/
+package lookaside
+
+import (
+	"errors"
+
+	"github.com/madflojo/hord"
+)
+
+// Config provides the configuration options for the Lookaside driver.
+type Config struct {
+	Database hord.Database
+	Cache    hord.Database
+}
+
+// Lookaside is used to store data in a look-aside caching pattern. It also satisfies the Hord database interface.
+type Lookaside struct {
+	data  hord.Database
+	cache hord.Database
+}
+
+func Dial(cfg Config) (hord.Database, error) {
+	if (cfg.Database == nil) || (cfg.Cache == nil) {
+		return nil, hord.ErrInvalidDatabase
+	}
+
+	return &Lookaside{
+		data:  cfg.Database,
+		cache: cfg.Cache,
+	}, nil
+}
+
+// Setup will run the Setup function for both the database and the cache.
+func (db *Lookaside) Setup() error {
+	if db == nil || db.data == nil || db.cache == nil {
+		return hord.ErrNoDial
+	}
+
+	if err := db.data.Setup(); err != nil {
+		return err
+	}
+
+	if err := db.cache.Setup(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// HealthCheck will run the HealthCheck function for both the database and the cache.
+func (db *Lookaside) HealthCheck() error {
+	if db == nil || db.data == nil || db.cache == nil {
+		return hord.ErrNoDial
+	}
+
+	dataErr := db.data.HealthCheck()
+	cacheErr := db.cache.HealthCheck()
+
+	if dataErr != nil {
+		return dataErr
+	} else if cacheErr != nil {
+		return cacheErr
+	}
+
+	return nil
+}
+
+// Get will get the data from the cache database. If not found, it uses a look-aside pattern to fetch from the data database and store the data in the cache.
+func (db *Lookaside) Get(key string) ([]byte, error) {
+	if db == nil || db.data == nil || db.cache == nil {
+		return nil, hord.ErrNoDial
+	}
+
+	// Check the cache first
+	data, err := db.cache.Get(key)
+	if (err != nil) && !errors.Is(err, hord.ErrNil) {
+		return nil, err
+	} else if !errors.Is(err, hord.ErrNil) {
+		return data, nil
+	}
+
+	// Check the data database
+	data, err = db.data.Get(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Update the cache
+	err = db.cache.Set(key, data)
+	if err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+// Set will set the data in both the data and cache databases.
+func (db *Lookaside) Set(key string, data []byte) error {
+	if db == nil || db.data == nil || db.cache == nil {
+		return hord.ErrNoDial
+	}
+
+	err := db.data.Set(key, data)
+	if err != nil {
+		return err
+	}
+
+	// Update cache only if database Set was successful
+	err = db.cache.Set(key, data)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete will delete the data from both the data and cache databases.
+func (db *Lookaside) Delete(key string) error {
+	if db == nil || db.data == nil || db.cache == nil {
+		return hord.ErrNoDial
+	}
+
+	dataErr := db.data.Delete(key)
+	cacheErr := db.cache.Delete(key)
+
+	if dataErr != nil {
+		return dataErr
+	} else if cacheErr != nil {
+		return cacheErr
+	}
+
+	return nil
+}
+
+// Keys will return the keys from the data database.
+func (db *Lookaside) Keys() ([]string, error) {
+	if db == nil || db.data == nil || db.cache == nil {
+		return nil, hord.ErrNoDial
+	}
+
+	return db.data.Keys()
+}
+
+// Close will close the connections to both the database and the cache.
+func (db *Lookaside) Close() {
+	if db != nil && db.data != nil && db.cache != nil {
+		db.data.Close()
+		db.cache.Close()
+	}
+}

--- a/drivers/cache/lookaside/lookaside.go
+++ b/drivers/cache/lookaside/lookaside.go
@@ -84,6 +84,7 @@ package lookaside
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/madflojo/hord"
 )
@@ -169,7 +170,7 @@ func (db *Lookaside) Get(key string) ([]byte, error) {
 	// Update the cache
 	err = db.cache.Set(key, data)
 	if err != nil {
-		return data, err
+		return data, fmt.Errorf("%w: %w", hord.ErrCacheError, err)
 	}
 
 	return data, nil

--- a/drivers/cache/lookaside/lookaside.go
+++ b/drivers/cache/lookaside/lookaside.go
@@ -101,7 +101,7 @@ type Lookaside struct {
 	cache hord.Database
 }
 
-func Dial(cfg Config) (hord.Database, error) {
+func Dial(cfg Config) (*Lookaside, error) {
 	if (cfg.Database == nil) || (cfg.Cache == nil) {
 		return nil, hord.ErrInvalidDatabase
 	}

--- a/drivers/cache/lookaside/lookaside.go
+++ b/drivers/cache/lookaside/lookaside.go
@@ -114,7 +114,7 @@ func Dial(cfg Config) (hord.Database, error) {
 
 // Setup will run the Setup function for both the database and the cache.
 func (db *Lookaside) Setup() error {
-	if db.data == nil || db.cache == nil {
+	if db == nil || db.data == nil || db.cache == nil {
 		return hord.ErrNoDial
 	}
 
@@ -221,6 +221,25 @@ func (db *Lookaside) Keys() ([]string, error) {
 	}
 
 	return db.data.Keys()
+}
+
+// CacheKeys will return the keys from the cache database.
+func (db *Lookaside) CacheKeys() ([]string, error) {
+	if db == nil || db.data == nil || db.cache == nil {
+		return nil, hord.ErrNoDial
+	}
+
+	return db.cache.Keys()
+}
+
+// GetCache will return the cache database.
+func (db *Lookaside) GetCache() hord.Database {
+	return db.cache
+}
+
+// GetDatabase will return the data database.
+func (db *Lookaside) GetDatabase() hord.Database {
+	return db.data
 }
 
 // Close will close the connections to both the database and the cache.

--- a/drivers/cache/lookaside/lookaside_test.go
+++ b/drivers/cache/lookaside/lookaside_test.go
@@ -1,0 +1,461 @@
+package lookaside
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/madflojo/hord"
+	"github.com/madflojo/hord/drivers/mock"
+)
+
+// Test Errors used for testing purposes
+var (
+	ErrDatabaseTest = errors.New("database error")
+	ErrCacheTest    = errors.New("cache error")
+)
+
+// setupCache is a helper function to create a new Cache driver using the provided database and cache Config.
+func setupCache(cacheConfig mock.Config, databaseConfig mock.Config) (hord.Database, error) {
+	database, err := mock.Dial(databaseConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	cache, err := mock.Dial(cacheConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return Dial(Config{
+		Database: database,
+		Cache:    cache,
+	})
+}
+
+func TestDial(t *testing.T) {
+	unitTests := map[string]struct {
+		config        Config
+		expectedError error
+	}{
+		"No Config": {
+			config:        Config{},
+			expectedError: hord.ErrInvalidDatabase,
+		},
+		"No Database": {
+			config: Config{
+				Cache: &mock.Database{},
+			},
+			expectedError: hord.ErrInvalidDatabase,
+		},
+		"No Cache": {
+			config: Config{
+				Database: &mock.Database{},
+			},
+			expectedError: hord.ErrInvalidDatabase,
+		},
+		"Happy Path": {
+			config: Config{
+				Database: &mock.Database{},
+				Cache:    &mock.Database{},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			_, err := Dial(test.config)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Dial(%v) returned error: %s, expected %s", test.config, err, test.expectedError)
+			}
+		})
+	}
+}
+
+func TestSetup(t *testing.T) {
+	unitTests := map[string]struct {
+		databaseError error
+		cacheError    error
+		expectedError error
+	}{
+		"Database Error": {
+			databaseError: ErrDatabaseTest,
+			cacheError:    nil,
+			expectedError: ErrDatabaseTest,
+		},
+		"Cache Error": {
+			databaseError: nil,
+			cacheError:    ErrCacheTest,
+			expectedError: ErrCacheTest,
+		},
+		"Both Errors": {
+			databaseError: ErrDatabaseTest,
+			cacheError:    ErrCacheTest,
+			expectedError: ErrDatabaseTest,
+		},
+		"Happy Path": {
+			databaseError: nil,
+			cacheError:    nil,
+			expectedError: nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			databaseConfig := mock.Config{
+				SetupFunc: func() error {
+					return test.databaseError
+				},
+			}
+			cacheConfig := mock.Config{
+				SetupFunc: func() error {
+					return test.cacheError
+				},
+			}
+
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			err = db.Setup()
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Setup() returned error: %s, expected %s", err, test.expectedError)
+			}
+		})
+	}
+}
+
+func TestHealthCheck(t *testing.T) {
+	unitTests := map[string]struct {
+		databaseError error
+		cacheError    error
+		expectedError error
+	}{
+		"Database Error": {
+			databaseError: ErrDatabaseTest,
+			cacheError:    nil,
+			expectedError: ErrDatabaseTest,
+		},
+		"Cache Error": {
+			databaseError: nil,
+			cacheError:    ErrCacheTest,
+			expectedError: ErrCacheTest,
+		},
+		"Both Errors": {
+			databaseError: ErrDatabaseTest,
+			cacheError:    ErrCacheTest,
+			expectedError: ErrDatabaseTest,
+		},
+		"Happy Path": {
+			databaseError: nil,
+			cacheError:    nil,
+			expectedError: nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			databaseConfig := mock.Config{
+				HealthCheckFunc: func() error {
+					return test.databaseError
+				},
+			}
+			cacheConfig := mock.Config{
+				HealthCheckFunc: func() error {
+					return test.cacheError
+				},
+			}
+
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			err = db.HealthCheck()
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("HealthCheck() returned error: %s, expected %s", err, test.expectedError)
+			}
+		})
+	}
+}
+
+func TestGet(t *testing.T) {
+	cacheConfig := mock.Config{
+		GetFunc: func(key string) ([]byte, error) {
+			switch key {
+			case "cache-hit":
+				return []byte("cache-data"), nil
+			case "cache-miss":
+				return nil, hord.ErrNil
+			case "cache-error":
+				return nil, ErrCacheTest
+			case "cache-write-error":
+				return nil, hord.ErrNil
+			case "database-error":
+				return nil, hord.ErrNil
+			}
+			return nil, errors.New("Unexpected Cache Error")
+		},
+		SetFunc: func(key string, _ []byte) error {
+			if key == "cache-write-error" {
+				return ErrCacheTest
+			}
+			return nil
+		},
+	}
+	databaseConfig := mock.Config{
+		GetFunc: func(key string) ([]byte, error) {
+			switch key {
+			case "cache-hit":
+				return nil, errors.New("Expected Cache Hit")
+			case "cache-miss":
+				return []byte("database-data"), nil
+			case "cache-error":
+				return nil, errors.New("Expected Cache Error")
+			case "cache-write-error":
+				return nil, nil
+			case "database-error":
+				return nil, ErrDatabaseTest
+			}
+			return nil, errors.New("Unexpected Database Error")
+		},
+	}
+
+	unitTests := map[string]struct {
+		key           string
+		expectedError error
+		expectedData  []byte
+	}{
+		"Cache Hit": {
+			key:           "cache-hit",
+			expectedError: nil,
+			expectedData:  []byte("cache-data"),
+		},
+		"Cache Miss": {
+			key:           "cache-miss",
+			expectedError: nil,
+			expectedData:  []byte("database-data"),
+		},
+		"Cache Error": {
+			key:           "cache-error",
+			expectedError: ErrCacheTest,
+			expectedData:  nil,
+		},
+		"Cache Write Error": {
+			key:           "cache-write-error",
+			expectedError: ErrCacheTest,
+			expectedData:  nil,
+		},
+		"Database Error": {
+			key:           "database-error",
+			expectedError: ErrDatabaseTest,
+			expectedData:  nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			data, err := db.Get(test.key)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
+			}
+			if string(data) != string(test.expectedData) {
+				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, data, test.expectedData)
+			}
+		})
+	}
+}
+
+func TestSet(t *testing.T) {
+	cacheValue := []byte("")
+	databaseValue := []byte("")
+
+	cacheConfig := mock.Config{
+		SetFunc: func(key string, data []byte) error {
+			cacheValue = nil
+			switch key {
+			case "happy-path":
+				cacheValue = data
+				return nil
+			case "cache-error":
+				return ErrCacheTest
+			case "database-error":
+				cacheValue = data
+				return nil
+			}
+			return errors.New("Unexpected Cache Error")
+		},
+	}
+	databaseConfig := mock.Config{
+		SetFunc: func(key string, data []byte) error {
+			databaseValue = nil
+			switch key {
+			case "happy-path":
+				databaseValue = data
+				return nil
+			case "cache-error":
+				databaseValue = data
+				return nil
+			case "database-error":
+				return ErrDatabaseTest
+			}
+			return errors.New("Unexpected Database Error")
+		},
+	}
+
+	unitTests := map[string]struct {
+		key                   string
+		data                  []byte
+		expectedError         error
+		expectedCacheValue    []byte
+		expectedDatabaseValue []byte
+	}{
+		"Cache Error": {
+			key:                   "cache-error",
+			data:                  []byte("cache-error-data"),
+			expectedError:         ErrCacheTest,
+			expectedCacheValue:    nil,
+			expectedDatabaseValue: []byte("cache-error-data"),
+		},
+		"Database Error": {
+			key:                   "database-error",
+			data:                  []byte("database-error-data"),
+			expectedError:         ErrDatabaseTest,
+			expectedCacheValue:    nil,
+			expectedDatabaseValue: nil,
+		},
+		"Happy Path": {
+			key:                   "happy-path",
+			data:                  []byte("happy-path-data"),
+			expectedError:         nil,
+			expectedCacheValue:    []byte("happy-path-data"),
+			expectedDatabaseValue: []byte("happy-path-data"),
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			err = db.Set(test.key, test.data)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
+			}
+			if !bytes.Equal(cacheValue, test.expectedCacheValue) {
+				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, cacheValue, test.expectedCacheValue)
+			}
+			if !bytes.Equal(databaseValue, test.expectedDatabaseValue) {
+				t.Errorf("Get(%s) returned data: %s, expected %s", test.key, databaseValue, test.expectedDatabaseValue)
+			}
+		})
+	}
+}
+
+func TestDelete(t *testing.T) {
+	cacheConfig := mock.Config{
+		DeleteFunc: func(key string) error {
+			switch key {
+			case "happy-path":
+				return nil
+			case "cache-error":
+				return ErrCacheTest
+			case "database-error":
+				return nil
+			}
+			return errors.New("Unexpected Cache Error")
+		},
+	}
+	databaseConfig := mock.Config{
+		DeleteFunc: func(key string) error {
+			switch key {
+			case "happy-path":
+				return nil
+			case "cache-error":
+				return nil
+			case "database-error":
+				return ErrDatabaseTest
+			}
+			return errors.New("Unexpected Database Error")
+		},
+	}
+
+	unitTests := map[string]struct {
+		key           string
+		expectedError error
+	}{
+		"Cache Error": {
+			key:           "cache-error",
+			expectedError: ErrCacheTest,
+		},
+		"Database Error": {
+			key:           "database-error",
+			expectedError: ErrDatabaseTest,
+		},
+		"Happy Path": {
+			key:           "happy-path",
+			expectedError: nil,
+		},
+	}
+
+	for name, test := range unitTests {
+		t.Run(name, func(t *testing.T) {
+			db, err := setupCache(cacheConfig, databaseConfig)
+			if err != nil {
+				t.Fatalf("Failed to connect to database - %s", err)
+			}
+
+			err = db.Delete(test.key)
+			if !errors.Is(err, test.expectedError) {
+				t.Errorf("Get(%s) returned error: %s, expected %s", test.key, err, test.expectedError)
+			}
+		})
+	}
+}
+
+func TestKeys(t *testing.T) {
+	databaseConfig := mock.Config{
+		KeysFunc: func() ([]string, error) {
+			return []string{"database-key"}, nil
+		},
+	}
+	cacheConfig := mock.Config{
+		KeysFunc: func() ([]string, error) {
+			return []string{"cache-key"}, nil
+		},
+	}
+
+	db, err := setupCache(cacheConfig, databaseConfig)
+	if err != nil {
+		t.Fatalf("Failed to connect to database - %s", err)
+	}
+
+	keys, err := db.Keys()
+	if err != nil {
+		t.Errorf("Keys() returned error: %s", err)
+	}
+	if keys[0] != "database-key" {
+		t.Errorf("Keys() returned data: %v, expected %v", keys, []string{"database-key"})
+	}
+}
+
+func TestClose(t *testing.T) {
+	databaseConfig := mock.Config{}
+	cacheConfig := mock.Config{}
+
+	db, err := setupCache(cacheConfig, databaseConfig)
+	if err != nil {
+		t.Fatalf("Failed to connect to database - %s", err)
+	}
+
+	db.Close()
+}

--- a/drivers/cache/lookaside/lookaside_test.go
+++ b/drivers/cache/lookaside/lookaside_test.go
@@ -248,6 +248,11 @@ func TestGet(t *testing.T) {
 			expectedError: ErrCacheTest,
 			expectedData:  nil,
 		},
+		"Cache Write Wrapper Error": {
+			key:           "cache-write-error",
+			expectedError: hord.ErrCacheError,
+			expectedData:  nil,
+		},
 		"Database Error": {
 			key:           "database-error",
 			expectedError: ErrDatabaseTest,

--- a/hord.go
+++ b/hord.go
@@ -104,6 +104,7 @@ var (
 	ErrNil             = fmt.Errorf("Nil value returned from database")
 	ErrNoDial          = fmt.Errorf("No database connection defined, did you dial?")
 	ErrInvalidDatabase = fmt.Errorf("Database cannot be nil")
+	ErrCacheError      = fmt.Errorf("Cache error")
 )
 
 // ValidKey checks if a key is valid.

--- a/hord.go
+++ b/hord.go
@@ -99,10 +99,11 @@ type Database interface {
 
 // Common Errors Used by Hord Drivers
 var (
-	ErrInvalidKey  = fmt.Errorf("Key cannot be nil")
-	ErrInvalidData = fmt.Errorf("Data cannot be empty")
-	ErrNil         = fmt.Errorf("Nil value returned from database")
-	ErrNoDial      = fmt.Errorf("No database connection defined, did you dial?")
+	ErrInvalidKey      = fmt.Errorf("Key cannot be nil")
+	ErrInvalidData     = fmt.Errorf("Data cannot be empty")
+	ErrNil             = fmt.Errorf("Nil value returned from database")
+	ErrNoDial          = fmt.Errorf("No database connection defined, did you dial?")
+	ErrInvalidDatabase = fmt.Errorf("Database cannot be nil")
 )
 
 // ValidKey checks if a key is valid.


### PR DESCRIPTION
# Overview
This feature adds a Cache driver which provides a simple look-aside caching pattern. It satisfies the Database interface and takes in two other `hord.Database` in it's configuration. The following is an example is a setup using a Cassandra database with a Redis cache:

```
// Handle Cassandra connection
var cdb hord.Database
cdb, err := cassandra.Dial(cassandra.Config{})
if err != nil {
	// Handle connection error
}

// Handle Redis connection
var rdb hord.Database
rdb, err = redis.Dial(redis.Config{})
if err != nil {
	// Handle connection error
}

var db hord.Database
db, err := cache.Dial(cache.Config{
	Database: cdb,
	Cache: rdb,
})
if err != nil {
	// Handle connection error
}
```
The following is a quick benchmark of the setup found above:
```
Testing with 10000 keys
Set: 14.020334231s
Get: 1.070310995s
Get (Uncached): 12.615694324s
```
In conclusion, this Cache driver provides a boost in performance within the same Database interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new package `cache` with functions for database operations and a `Cache` struct for managing data.
	- Added a `lookaside` package for a database driver to handle cache operations.
- **Tests**
	- Included test functions for the `cache` and `lookaside` packages to validate database interactions and cache functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->